### PR TITLE
Fix some clippy lints (and add a trait impl).

### DIFF
--- a/src/core/value.rs
+++ b/src/core/value.rs
@@ -10,11 +10,11 @@ use crate::core::Args;
 pub struct ListRef(Rc<RefCell<Vec<Value>>>);
 
 impl ListRef {
-    pub fn borrow(&self) -> std::cell::Ref<Vec<Value>> {
+    pub fn borrow(&self) -> std::cell::Ref<'_, Vec<Value>> {
         self.0.borrow()
     }
 
-    pub fn borrow_mut(&self) -> std::cell::RefMut<Vec<Value>> {
+    pub fn borrow_mut(&self) -> std::cell::RefMut<'_, Vec<Value>> {
         self.0.borrow_mut()
     }
 }
@@ -23,11 +23,11 @@ impl ListRef {
 pub struct DictRef(Rc<RefCell<IndexMap<String, Value>>>);
 
 impl DictRef {
-    pub fn borrow(&self) -> std::cell::Ref<IndexMap<String, Value>> {
+    pub fn borrow(&self) -> std::cell::Ref<'_, IndexMap<String, Value>> {
         self.0.borrow()
     }
 
-    pub fn borrow_mut(&self) -> std::cell::RefMut<IndexMap<String, Value>> {
+    pub fn borrow_mut(&self) -> std::cell::RefMut<'_, IndexMap<String, Value>> {
         self.0.borrow_mut()
     }
 }
@@ -36,11 +36,11 @@ impl DictRef {
 pub struct ClassInstanceRef(Rc<RefCell<crate::eval::ClassInstance>>);
 
 impl ClassInstanceRef {
-    pub fn borrow(&self) -> std::cell::Ref<crate::eval::ClassInstance> {
+    pub fn borrow(&self) -> std::cell::Ref<'_, crate::eval::ClassInstance> {
         self.0.borrow()
     }
 
-    pub fn borrow_mut(&self) -> std::cell::RefMut<crate::eval::ClassInstance> {
+    pub fn borrow_mut(&self) -> std::cell::RefMut<'_, crate::eval::ClassInstance> {
         self.0.borrow_mut()
     }
 }
@@ -49,11 +49,11 @@ impl ClassInstanceRef {
 pub struct ClassRef(Rc<RefCell<crate::eval::Class>>);
 
 impl ClassRef {
-    pub fn borrow(&self) -> std::cell::Ref<crate::eval::Class> {
+    pub fn borrow(&self) -> std::cell::Ref<'_, crate::eval::Class> {
         self.0.borrow()
     }
 
-    pub fn borrow_mut(&self) -> std::cell::RefMut<crate::eval::Class> {
+    pub fn borrow_mut(&self) -> std::cell::RefMut<'_, crate::eval::Class> {
         self.0.borrow_mut()
     }
 }
@@ -646,7 +646,7 @@ impl Value {
     }
 
     /// Get a reference to `Vec<Value>` for function parameter binding
-    pub fn as_ref_vec_value(&self) -> Result<std::cell::Ref<Vec<Value>>> {
+    pub fn as_ref_vec_value(&self) -> Result<std::cell::Ref<'_, Vec<Value>>> {
         match self {
             Value::List(list_ref) => Ok(list_ref.borrow()),
             _ => Err(anyhow!("Cannot borrow {} as &Vec<Value>", self.type_name())),
@@ -654,7 +654,7 @@ impl Value {
     }
 
     /// Get a mutable reference to `Vec<Value>` for function parameter binding
-    pub fn as_mut_ref_vec_value(&self) -> Result<std::cell::RefMut<Vec<Value>>> {
+    pub fn as_mut_ref_vec_value(&self) -> Result<std::cell::RefMut<'_, Vec<Value>>> {
         match self {
             Value::List(list_ref) => Ok(list_ref.borrow_mut()),
             _ => Err(anyhow!(
@@ -667,7 +667,7 @@ impl Value {
     /// Get a reference to IndexMap<String, Value> for function parameter binding
     pub fn as_ref_indexmap_string_value(
         &self,
-    ) -> Result<std::cell::Ref<indexmap::IndexMap<String, Value>>> {
+    ) -> Result<std::cell::Ref<'_, indexmap::IndexMap<String, Value>>> {
         match self {
             Value::Dict(dict_ref) => Ok(dict_ref.borrow()),
             _ => Err(anyhow!(
@@ -680,7 +680,7 @@ impl Value {
     /// Get a mutable reference to IndexMap<String, Value> for function parameter binding
     pub fn as_mut_ref_indexmap_string_value(
         &self,
-    ) -> Result<std::cell::RefMut<indexmap::IndexMap<String, Value>>> {
+    ) -> Result<std::cell::RefMut<'_, indexmap::IndexMap<String, Value>>> {
         match self {
             Value::Dict(dict_ref) => Ok(dict_ref.borrow_mut()),
             _ => Err(anyhow!(

--- a/src/core/value_interop.rs
+++ b/src/core/value_interop.rs
@@ -321,6 +321,17 @@ impl BorrowMutValueAs<Vec<Value>> for Value {
     }
 }
 
+impl BorrowValueAs<[Value]> for Value {
+    type Guard<'a> = std::cell::Ref<'a, [Value]>;
+
+    fn borrow_value_as(&self) -> Result<Self::Guard<'_>, anyhow::Error> {
+        match self {
+            Value::List(list_ref) => Ok(std::cell::Ref::map(list_ref.borrow(), |v| &v[..])),
+            _ => Err(anyhow!("Cannot borrow {} as [Value]", self.type_name())),
+        }
+    }
+}
+
 impl BorrowValueAs<indexmap::IndexMap<String, Value>> for Value {
     type Guard<'a> = std::cell::Ref<'a, indexmap::IndexMap<String, Value>>;
 

--- a/tests/user/functions.rs
+++ b/tests/user/functions.rs
@@ -20,7 +20,7 @@ fn fn_no_args() -> f64 {
 }
 
 #[rustleaf]
-fn fn_borrow(v: &Vec<Value>) -> usize {
+fn fn_borrow(v: &[Value]) -> usize {
     v.len()
 }
 

--- a/tests/user/script_loader.rs
+++ b/tests/user/script_loader.rs
@@ -6,7 +6,6 @@ use std::fs;
 /// script and calls a function from it. This pattern shows how RustLeaf can be
 /// embedded in larger applications where users provide scripts with specific
 /// function contracts.
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -43,10 +42,7 @@ mod tests {
 
             assert!(
                 (y - expected).abs() < 1e-10,
-                "polynomial({}) = {}, expected {}",
-                input,
-                y,
-                expected
+                "polynomial({input}) = {y}, expected {expected}"
             );
         }
     }


### PR DESCRIPTION
This pull request updates several borrow methods in `src/core/value.rs` to use explicit lifetime annotations, improves trait implementations for borrowing slices of values, and adjusts a test function to accept slices instead of vectors. These changes enhance code clarity and flexibility when working with borrowed data in RustLeaf.

Borrow method lifetime annotations:

* Updated all `borrow` and `borrow_mut` methods in `ListRef`, `DictRef`, `ClassInstanceRef`, and `ClassRef` to use explicit lifetime parameters for their return types, improving clarity and type safety. [[1]](diffhunk://#diff-74071f80ccb9959b6b56502b3e64cbda9f68b9e2cbf068c2473c36cccddd445cL13-R17) [[2]](diffhunk://#diff-74071f80ccb9959b6b56502b3e64cbda9f68b9e2cbf068c2473c36cccddd445cL26-R30) [[3]](diffhunk://#diff-74071f80ccb9959b6b56502b3e64cbda9f68b9e2cbf068c2473c36cccddd445cL39-R43) [[4]](diffhunk://#diff-74071f80ccb9959b6b56502b3e64cbda9f68b9e2cbf068c2473c36cccddd445cL52-R56)
* Updated related methods in the `Value` struct to use explicit lifetimes for references to `Vec<Value>` and `IndexMap<String, Value>`. [[1]](diffhunk://#diff-74071f80ccb9959b6b56502b3e64cbda9f68b9e2cbf068c2473c36cccddd445cL649-R657) [[2]](diffhunk://#diff-74071f80ccb9959b6b56502b3e64cbda9f68b9e2cbf068c2473c36cccddd445cL670-R670) [[3]](diffhunk://#diff-74071f80ccb9959b6b56502b3e64cbda9f68b9e2cbf068c2473c36cccddd445cL683-R683)

Trait and type improvements:

* Implemented the `BorrowValueAs<[Value]>` trait for `Value`, allowing safe borrowing of slices from lists and improving interoperability.

Test function adjustment:

* Changed the test function `fn_borrow` in `tests/user/functions.rs` to accept a slice (`&[Value]`) instead of a vector, reflecting the new borrowing capabilities.

Minor test improvements:

* Simplified the assertion formatting in `tests/user/script_loader.rs` for better readability.